### PR TITLE
Added root option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "browser": true,
     "es6": true


### PR DESCRIPTION
This fixes the issue with "Definition for rule 'keyword-spacing' was not found  keyword-spacing". Is seems like eslint used the file from Drupal instead of  the one defined in the theme.
